### PR TITLE
Improve emote bugs page

### DIFF
--- a/faq/emotes-bugs/broken-emote-textures.md
+++ b/faq/emotes-bugs/broken-emote-textures.md
@@ -1,0 +1,51 @@
+---
+description: Emotes have bugged textures (1.17+)
+---
+
+# Broken Emote textures
+
+## Shader Mod issues
+
+Mods that allow the usage of custom shaders will break emotes due to them overriding/replacing the vanilla Shader which ItemsAdder uses for the Emotes feature.
+
+The only way to *"fix"* this is by disabling the shaders themself or removing the shader mod in question.
+
+{% tabs %}
+{% tab title="With Shaders on (Bug)" %}
+![shader bug](<../../.gitbook/assets/image (51) (2) (1).png>)
+{% endtab %}
+
+{% tab title="With Shaders off (No Bug)" %}
+![no shader bug](<../../.gitbook/assets/image (64).png>)
+{% endtab %}
+{% endtabs %}
+
+Known shader mods that cause issues:
+
+### Optifine
+
+Related issue: [https://github.com/sp614x/optifine/issues/6391](https://github.com/sp614x/optifine/issues/6391)
+
+### IrisShaders
+
+Related issue: [https://github.com/IrisShaders/Iris/issues/1042](https://github.com/IrisShaders/Iris/issues/1042)
+
+## Mods that change the player skins
+
+A mod may change the default player model/skin and can therefore be affected by ItemsAdder's shader manipulations, or vice-versa.
+
+Known Mods that cause issues:
+
+### 3DSkinLayers
+
+The mod alters the outer skin layer to make them appear in 3D, which alters the player model itself.
+
+A possible fix is to disable `3D Skulls` and `3D Skull Items` in the mod's settings.\
+There is currently no workaround for using 3D layers in Emote animations.
+
+Additional information can be found in the related issue: [https://github.com/tr7zw/3d-Skin-Layers/issues/45](https://github.com/tr7zw/3d-Skin-Layers/issues/45)
+
+### Customizable Player Models
+
+This mod allows the complete customization of the player model including replacing parts of it or the model as a whole.\
+Due to this will Emotes not display properly in ItemsAdder and there is currently no fix available outside of not using the mod or not using the Emote animations.

--- a/faq/emotes-bugs/textures-broken-by-shaders-mod.md
+++ b/faq/emotes-bugs/textures-broken-by-shaders-mod.md
@@ -5,43 +5,9 @@ description: Emotes textures look broken when using custom shaders mods (1.17+)
 # Textures broken by shaders mod
 
 {% hint style="warning" %}
-**This "bug" can't be fixed for now**
+**Page moved!**
 
-It's a Optifine/Iris mod incompatibility I cannot fix for now without a change on these two shaders mods.
+The page has been moved and can now be found at the location linked below.
 {% endhint %}
 
-{% tabs %}
-{% tab title="With shaders (bug)" %}
-![](<../../.gitbook/assets/image (51) (2) (1).png>)
-{% endtab %}
-
-{% tab title="Without shaders (no bug)" %}
-![](<../../.gitbook/assets/image (64).png>)
-{% endtab %}
-{% endtabs %}
-
-## What was the cause of this bug?
-
-### Optifine issue
-
-Optifine has a limitation which doesn't allow custom emotes to work correctly if you have any custom Optifine shader installed.
-
-You have to disable the **Optifine** shaders temporarily or temporarily live with the issue.
-
-I already contacted Optifine developer about this: [https://github.com/sp614x/optifine/issues/6391](https://github.com/sp614x/optifine/issues/6391)
-
-### Iris Shaders issue
-
-Iris has a limitation which doesn't allow custom emotes to work correctly if you have any custom Iris custom shader installed.
-
-I already contacted Iris developers about this: [https://github.com/IrisShaders/Iris/issues/1042](https://github.com/IrisShaders/Iris/issues/1042)
-
-### 3DSkinLayers
-
-When using the [3DSkinLayers](https://www.curseforge.com/minecraft/mc-mods/skin-layers-3d) mod will Emotes not render properly.\
-This is because the mod alters how the extra layers are rendered, which messes up the placement of the skin parts in ItemsAdder.
-
-To fix this, open the settings of 3DSkinLayers and set `3D Skulls` and `3D Skull Items` (For customized skulls in inventories) to `Off`.\
-There is currently no workaround for using 3D layers in Emote animations.
-
-Extra info can be found here: [https://github.com/tr7zw/3d-Skin-Layers/issues/45](https://github.com/tr7zw/3d-Skin-Layers/issues/45)
+{% page-ref page="../broken-emote-textures.md" %}


### PR DESCRIPTION
This improves the emotes bug page in a few ways.

It first of all moves the content to a more generic named page (`broken-emote-textures.md`) as the current one implies it to only be an issue with shaders, which is completely wrong.

Next does it also add "Customizable Player Models" as an incompatible mod to the list.

Finally is it splitting up the page into Shaders and Mods that can/will change the player model.

To not break existing links did I keep the old page, but made it link to the new one... I hope the page-ref thing works.