### PR TITLE
Update loots.md

### DIFF
--- a/plugin-usage/adding-content/loots.md
+++ b/plugin-usage/adding-content/loots.md
@@ -130,6 +130,7 @@ loots:
   mobs:
     villager:
       type: VILLAGER
+      ignore_spawner: true
       nbt:
         profession:
           path: VillagerData.profession


### PR DESCRIPTION
This is regarding this issue, that was opened for the mob loots (https://github.com/PluginBugs/Issues-ItemsAdder/issues/3332). Nowhere on the wiki the `ignore_spawner` is mentioned.