### PR TITLE
Remove global.rs link

### DIFF
--- a/compatibility-with-other-plugins/compatible/chatcontrol-red.md
+++ b/compatibility-with-other-plugins/compatible/chatcontrol-red.md
@@ -23,7 +23,7 @@ Obviously you have to use your own [font\_image ](../../plugin-usage/adding-cont
 ## Text effects
 
 Normally the ItemsAdder text effects don't work with ChatControl Red.\
-But if you add this to your `rules` folder of ChatControl Red, they will work. (I put this in [`global.rs`](http://global.rs/)).
+But if you add this to your `rules` folder of ChatControl Red, they will work. (I put this in `global.rs`).
 
 ```
 match <r\s([^>]+)>


### PR DESCRIPTION
There is no reason for it actually linking to a site since it's not meant to be treated as a domain (Also, the site linked is some russian Map thing...)