### PR TITLE
Adding an warning in textured-armor

### DIFF
--- a/plugin-usage/adding-content/textured-armor.md
+++ b/plugin-usage/adding-content/textured-armor.md
@@ -191,7 +191,7 @@ To create other pieces you just have to repeat the following method and change t
 ```
 
 {% hint style="warning" %}
-Make sure that no material is set. It won't work if a material has been set.
+Make sure that no `material` property is set. This is handled automatically by the plugin for custom textured armors. Armor won't work if a `material` has been set.
 {% endhint %}
 
 The `custom_armor` property is important, it makes the plugin apply the previous `armors_renderer` setting to this armor piece.

--- a/plugin-usage/adding-content/textured-armor.md
+++ b/plugin-usage/adding-content/textured-armor.md
@@ -190,6 +190,10 @@ To create other pieces you just have to repeat the following method and change t
         armorToughness: 1
 ```
 
+{% hint style="warning" %}
+Make sure that no material is set. It won't work if a material has been set.
+{% endhint %}
+
 The `custom_armor` property is important, it makes the plugin apply the previous `armors_renderer` setting to this armor piece.
 
 In this case I didn't specify any `color` in the `specific_properties` field of the armor piece because it's automatically applied by the `custom_armor` property, inherited from the `armors_renderer`.


### PR DESCRIPTION
This pull request includes a small change to the `plugin-usage/adding-content/textured-armor.md` file. The change adds a warning to ensure that no material is set when creating custom armor pieces. (We've worked like 3h to realize that)

* [`plugin-usage/adding-content/textured-armor.md`](diffhunk://#diff-d43f8b3f6c38e9bd4ccefe6d37bcf3595adabbfd7e9e9b62d8cac05000d9e620R193-R196): Added a warning hint to ensure that no material is set, as it will not work if a material has been set.