### PR TITLE
:speech_balloon: Update Minecraft Wiki Hyperlinks

### DIFF
--- a/faq/emotes-with-more-joins.md
+++ b/faq/emotes-with-more-joins.md
@@ -14,7 +14,7 @@ Emotes with multiple joints animations look <mark style="color:red;">**awful**</
 
 The current emotes have the same style of Bedrock edition emotes, which follows the Mojang style guidelines.
 
-{% embed url="https://minecraft.fandom.com/wiki/Emotes" %}
+{% embed url="https://minecraft.wiki/w/Emotes" %}
 
 ### Reason 3
 

--- a/plugin-usage/adding-content/item-properties/basic.md
+++ b/plugin-usage/adding-content/item-properties/basic.md
@@ -91,7 +91,7 @@ attribute_modifiers:
     luck: 1.1
 ```
 
-These are the vanilla attribute modifiers, you can get more info here: [https://minecraft.gamepedia.com/Attribute#Attributes\_available\_on\_all\_living\_entities](https://minecraft.gamepedia.com/Attribute#Attributes_available_on_all_living_entities)
+These are the vanilla attribute modifiers, you can get more info here: [https://minecraft.wiki/w/Attribute](https://minecraft.wiki/w/Attribute)
 
 ## `durability`
 


### PR DESCRIPTION
Replaced hyperlinks to https://minecraft.fandom.com/ with https://minecraft.wiki/ as the fandom version is no longer maintained as actively. 