### PR TITLE
Remove LootChest from the Not compatible page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -122,6 +122,7 @@
     * [AlixAnimations](https://alixanimations.gitbook.io/alixanimations/fundamentals/getting-set-up/actions/compatible-plugins/itemsadder)
     * [HopperSorter](https://slowtomato-1.gitbook.io/hoppersorter-wiki/compatability/itemsadder)
     * [HeadsAnywhere](compatibility-with-other-plugins/compatible/headsanywhere.md)
+    * [LootChest](compatibility-with-other-plugins/compatible/lootchest.md)
 * [Contribute](contribute/README.md)
   * [Edit the English wiki](contribute/edit-the-english-wiki.md)
   * [Translate this wiki](contribute/translate-this-wiki.md)

--- a/compatibility-with-other-plugins/compatible/lootchest.md
+++ b/compatibility-with-other-plugins/compatible/lootchest.md
@@ -1,0 +1,4 @@
+# LootChest
+
+## [Download it here](https://www.spigotmc.org/resources/lootchest.61564)
+

--- a/compatibility-with-other-plugins/not-compatible.md
+++ b/compatibility-with-other-plugins/not-compatible.md
@@ -11,5 +11,4 @@ I can't answer surely to this question because I can't know how every plugin in 
 * All plugins that uses **custom resourcepacks** (you can make them compatible if you've a minimum knowledge on how to merge resourcepacks manually, be sure to not replace ItemsAdder files and you're done)
 * [CraftEnhance](https://www.spigotmc.org/resources/custom-recipes-and-crafting-craftenhance.65058/), this plugin messes up ItemsAdder custom recipes logic and creates duplication bugs. So please don't use it
 * Plugins that customize crafting table behaviour and recipes
-* [LootChest ](https://www.spigotmc.org/resources/lootchest.61564/)can cause some [problems](https://github.com/LoneDev6/ItemsAdder/issues/15#issuecomment-512990849)
 * For now it's **not compatible** with **plugins** and world generators that **spawn mushroom** blocks with different faces to create custom textures. In the future I will add compatibility.

--- a/faq/i-cant-remove-furnitures-and-vehicles.md
+++ b/faq/i-cant-remove-furnitures-and-vehicles.md
@@ -1,5 +1,5 @@
 # I can't remove furnitures and vehicles
 
 * make sure you are running the latest [LoneLibs](https://www.spigotmc.org/resources/lonelibs.75974/), [ItemsAdder ](https://www.spigotmc.org/resources/%E2%9C%85must-have%E2%9C%85-itemsadder%E2%9C%A8textures-3d-models-huds-gui-emojis-ores-blocks-wings-tails-hats.73355/)and [ProtocolLib ](https://ci.dmulloy2.net/job/ProtocolLib/lastSuccessfulBuild/)versions
-* remove these plugins if you have them: **Armor Stand Tools** or **LootChest**
+* remove these plugins if you have them: **Armor Stand Tools**
 * make sure you have build / damage entities permissions for that area (**WorldGuard** or other permission plugins)


### PR DESCRIPTION
It's compatible since this update
https://www.spigotmc.org/resources/lootchest.61564/update?update=484387