### PR TITLE
Fix typo in self-hosting documentation

### DIFF
--- a/plugin-usage/plugin-configuration/resourcepack-hosting/self-hosting.md
+++ b/plugin-usage/plugin-configuration/resourcepack-hosting/self-hosting.md
@@ -1,7 +1,7 @@
 # Self hosting
 
 {% hint style="success" %}
-**Recommanded.**
+**Recommended.**
 {% endhint %}
 
 {% hint style="warning" %}


### PR DESCRIPTION
Fixed typo from Recomm**a**nded to Recomm**e**nded