### PR TITLE
added example pack for complex furniture, renamed crops example pack header, fixed a typo

### DIFF
--- a/adding-content/crops.md
+++ b/adding-content/crops.md
@@ -383,7 +383,7 @@ crops:
       billboard_textures_prefix: block/red_crop_stage_
 ```
 
-#### Auto genereate billboard based on custom models
+#### Auto generate billboard based on custom models
 
 ```yaml
 crops:
@@ -536,7 +536,7 @@ crops:
       items_id_prefix: blue_crop_stage_
 ```
 
-# Example pack
+# Example crops pack
 
 {% content-ref url="https://www.spigotmc.org/resources/itemsadder-crops.135776/" %}
 Guide

--- a/adding-content/furnitures/furniture-complex.md
+++ b/adding-content/furnitures/furniture-complex.md
@@ -105,3 +105,9 @@ Export the model. This is the model file that will be loaded by ItemsAdder.
 Get the item ingame using `/iaget my_furniture:ceiling_fan`.
 
 <figure><img src="../../.gitbook/assets/furniture-complex_002.webp" alt=""><figcaption></figcaption></figure>
+# Example complex furniture pack
+
+You can download an interesting advanced vehicles pack [here](https://www.spigotmc.org/resources/iaentities-animated-furniture-for-itemsadder.137775/)
+
+{% embed url="https://www.youtube.com/watch?v=x1Ak1muccAU" fullWidth="true" %}
+


### PR DESCRIPTION
Created from a reviewed GitDocs workspace.